### PR TITLE
fix namechange for bigscreen

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -101,7 +101,7 @@ class SIPSkill(FallbackSkill):
         self.gui.register_handler("voip.jarbas.unmuteCall", self.unmute_call)
         self.gui.register_handler("voip.jarbas.callContact", self.handle_call_contact_from_gui)
         self.gui.register_handler("voip.jarbas.updateConfig", self.handle_config_from_gui)
-        self.add_event('skill--voip.jarbasskills.home', self.show_homescreen)
+        self.add_event('skill-voip.jarbasskills.home', self.show_homescreen)
         
     def _on_web_settings_change(self):
         # TODO settings should be uploaded to backend when changed inside

--- a/res/desktop/skill-voip.desktop
+++ b/res/desktop/skill-voip.desktop
@@ -5,7 +5,7 @@ Version=1.0
 Terminal=false
 Type=Application
 Name=VoIP
-Exec=mycroft-gui-app --hideTextInput --skill=skill--voip.jarbasskills.home
+Exec=mycroft-gui-app --hideTextInput --skill=skill-voip.jarbasskills.home
 Icon=voip-skill
 Categories=VoiceApp
 StartupNotify=false


### PR DESCRIPTION
Name changes breaks skill in bigscreen, adopt new repository name

Also requires updating the skill.json on pling to use skill-voip instead of skill--voip